### PR TITLE
Strip all org-mode metadata from summary

### DIFF
--- a/deft.el
+++ b/deft.el
@@ -501,12 +501,7 @@ form -*-mode-*-."
 (defcustom deft-strip-summary-regexp
   (concat "\\("
            "[\n\t]" ;; blank
-           "\\|^#\\+OPTIONS:.*$" ;; org-mode metadata
-           "\\|^#\\+LATEX_CMD:.*$" ;; org-mode-metadata
-           "\\|^#\\+LATEX_CLASS:.*$" ;; org-mode-metadata
-           "\\|^#\\+LATEX_HEADER:.*$" ;; org-mode-metadata
-           "\\|^#\\+STARTUP:.*$" ;; org-mode-metadata
-           "\\|^#\\+AUTHOR:.*$" ;; org-mode-metadata
+           "\\|^#\\+[[:upper:]_]:.*$" ;; org-mode metadata
            "\\)")
    "Regular expression to remove file contents displayed in summary.
    Presently removes blank lines and org-mode metadata statements."
@@ -844,7 +839,8 @@ used as title."
   "Parse the file CONTENTS, given the TITLE, and extract a summary.
 The summary is a string extracted from the contents following the
 title."
-  (let ((summary (replace-regexp-in-string deft-strip-summary-regexp " " contents)))
+  (let ((summary (let ((case-fold-search nil))
+                   (replace-regexp-in-string deft-strip-summary-regexp " " contents))))
     (if (and (not deft-use-filename-as-title) title)
         (if (string-match (regexp-quote title) summary)
             (deft-chomp (substring summary (match-end 0) nil))

--- a/deft.el
+++ b/deft.el
@@ -501,7 +501,7 @@ form -*-mode-*-."
 (defcustom deft-strip-summary-regexp
   (concat "\\("
            "[\n\t]" ;; blank
-           "\\|^#\\+[[:upper:]_]:.*$" ;; org-mode metadata
+           "\\|^#\\+[[:upper:]_]+:.*$" ;; org-mode metadata
            "\\)")
    "Regular expression to remove file contents displayed in summary.
    Presently removes blank lines and org-mode metadata statements."
@@ -841,11 +841,12 @@ The summary is a string extracted from the contents following the
 title."
   (let ((summary (let ((case-fold-search nil))
                    (replace-regexp-in-string deft-strip-summary-regexp " " contents))))
-    (if (and (not deft-use-filename-as-title) title)
-        (if (string-match (regexp-quote title) summary)
-            (deft-chomp (substring summary (match-end 0) nil))
-          "")
-      summary)))
+    (deft-chomp
+      (if (and title
+               (not deft-use-filename-as-title)
+               (string-match (regexp-quote title) summary))
+          (substring summary (match-end 0) nil)
+        summary))))
 
 (defun deft-cache-file (file)
   "Update file cache if FILE exists."


### PR DESCRIPTION
Use a more general regexp to strip org-mode metadata.

Unset case-fold-search when using the deft-strip-summary-regexp so that
character class [:upper:] matches only uppercase letters.