### PR TITLE
Try to prevent false title matches in org notes

### DIFF
--- a/deft.el
+++ b/deft.el
@@ -883,7 +883,11 @@ title."
     (deft-chomp
       (if (and title
                (not deft-use-filename-as-title)
-               (string-match (regexp-quote title) summary))
+               (string-match (regexp-quote
+                              (if deft-org-mode-title-prefix
+                                  (concat "^#+TITLE: " title)
+                                title))
+                             summary))
           (substring summary (match-end 0) nil)
         summary))))
 


### PR DESCRIPTION
- With the updated code, if `deft-org-mode-title-prefix` is non-nil,
title match with strictly happen with lines beginning with "^#+TITLE:
". This prevents false extractions of summary in the event that the
"title" string appears elsewhere in the note body too.

Example note:

#+TITLE: Many people
Some text here that should become part of the summary.
Many people are good people.

Without this patch, only "are good people" shows up in the summary.