### PR TITLE
Use file-truename to resolve symbolic links

### DIFF
--- a/deft.el
+++ b/deft.el
@@ -1384,7 +1384,7 @@ name."
 When OTHER is non-nil, open the file in another window.  When
 OTHER and SWITCH are both non-nil, switch to the other window.
 FILE must be a relative or absolute path, with extension."
-  (let ((buffer (find-file-noselect file)))
+  (let ((buffer (find-file-noselect (file-truename file))))
     (with-current-buffer buffer
       (hack-local-variables)
       (when deft-filter-regexp


### PR DESCRIPTION
A change initiated from
https://github.com/org-roam/org-roam/issues/518 causes org-roam to
only store files by their resolved symbolic link value.

Testcase:

0. Create a symbolic link from '/path/to/real/roam/dir' to '/easy/path'
1. Configure org-roam to use '/easy/path'
2. Update the roam index, it will store files with
'/path/to/real/roam/dir'
3. point deft to '/easy/path'

  (setq deft-recursive t)
  (setq deft-use-filter-string-for-filename t)
  (setq deft-default-extension "org")
  (setq deft-directory "/easy/path/" )

4. open a file using deft.

The result will be that it is opened using /easy/path and roam will
not be able to resolve it. Using `fie-truename` will actually expand
the symbolic link, opening it with /path/to/real/roam/dir.

I can understand if this breaks other things, so perhaps a flag is
more appropriate. What do you think?