### PR TITLE
Optionally ask for an extension when creating new files

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,8 +146,8 @@ search mode is indicated by an "R" in the mode line.
 Common file operations can also be carried out from within Deft.
 Files can be renamed using <kbd>C-c C-r</kbd> or deleted using <kbd>C-c C-d</kbd>.
 New files can also be created using <kbd>C-c C-n</kbd> for quick creation or
-<kbd>C-c C-m</kbd> for a filename prompt.  You can leave Deft at any time
-with <kbd>C-c C-q</kbd>.
+<kbd>C-c C-m</kbd> for a filename prompt; with a prefix argument, these operations
+ask for a file extension.  You can leave Deft at any time with <kbd>C-c C-q</kbd>.
 
 Unused files can be archived by pressing <kbd>C-c C-a</kbd>.  Files will be
 moved to `deft-archive-directory`, which is a directory named

--- a/deft.el
+++ b/deft.el
@@ -1450,11 +1450,15 @@ the newly created FILE."
       "\n\n")
      nil file nil)))
 
-(defun deft-new-file-named (slug)
+(defun deft-new-file-named (slug &optional arg)
   "Create a new file named SLUG.
-SLUG is the short file name, without a path or a file extension."
-  (interactive "sNew filename (without extension): ")
-  (let ((file (deft-absolute-filename slug)))
+SLUG is the short file name, without a path or a file extension.
+With prefix ARG, ask for a file extension."
+  (interactive "sNew filename (without extension): \nP")
+  (let* ((extension (and arg
+                         (completing-read "Extension: " deft-extensions
+                                          nil t nil nil deft-default-extension)))
+         (file (deft-absolute-filename slug extension)))
     (if (file-exists-p file)
         (message "Aborting, file already exists: %s" file)
       (deft-auto-populate-title-maybe file)
@@ -1465,12 +1469,14 @@ SLUG is the short file name, without a path or a file extension."
         (goto-char (point-max))))))
 
 ;;;###autoload
-(defun deft-new-file ()
+(defun deft-new-file (&optional arg)
   "Create a new file quickly.
-Use either an automatically generated filename or the filter string if non-nil
-and `deft-use-filter-string-for-filename' is set.  If the filter string is
-non-nil and title is not from filename, use it as the title."
-  (interactive)
+Use either an automatically generated filename or the filter
+string if non-nil and `deft-use-filter-string-for-filename' is
+set.  If the filter string is non-nil and title is not from
+filename, use it as the title.  The prefix ARG is passed to
+`deft-new-file-named'."
+  (interactive "P")
   (let (slug)
     (if (and deft-filter-regexp deft-use-filter-string-for-filename)
         ;; If the filter string is non-emtpy and titles are taken from
@@ -1479,7 +1485,7 @@ non-nil and title is not from filename, use it as the title."
       ;; If the filter string is empty, or titles are taken from file
       ;; contents, then use an automatically generated unique filename.
       (setq slug (deft-unused-slug)))
-    (deft-new-file-named slug)))
+    (deft-new-file-named slug arg)))
 
 (defun deft-filename-at-point ()
   "Return the name of the file represented by the button at the point.


### PR DESCRIPTION
Although Deft recognizes multiple file extensions, currently there is no built-in way to create files with extensions other than `deft-default-extension`. This patch makes the functions `deft-new-file` and `deft-new-file-named` accept an optional prefix argument: when invoked with a prefix argument, those functions ask for a file extension to be chosen from `deft-extensions`, defaulting to `deft-default-extension`.